### PR TITLE
Expose web stream read errors as node errors events

### DIFF
--- a/lib/conversions.js
+++ b/lib/conversions.js
@@ -70,7 +70,8 @@ class NodeReadable extends Readable {
                     } else {
                         this._reading = false;
                     }
-                });
+                })
+                .catch(e => this.emit('error', e));
         };
         doRead();
     }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "dependencies": {
     "is-stream": "^1.1.0",
-    "web-streams-polyfill": "git://github.com/gwicke/web-streams-polyfill#spec_performance_improvements"
+    "web-streams-polyfill": "^1.3.2"
   }
 }


### PR DESCRIPTION
Fixes #3.

This also bumps web-streams-polyfill to the latest release, since otherwise the outdated dependency for that causes issues (see https://github.com/creatorrr/web-streams-polyfill/issues/14), so closes #2 and fixes #1.

Tested with:

```js
const { ReadableStream, toWebReadableStream, toNodeReadable } = require(".");

let nodeReader = require('fs').createReadStream('/tmp/test.txt');
let webReader = toWebReadableStream(nodeReader);
let roundTrippedReader = toNodeReadable(webReader);

roundTrippedReader.pipe(process.stdout);
roundTrippedReader.on('error', (e) => console.log('Caught error', e.message));
```

If `/tmp/test.txt` exists, the contents should be printed. If not, an 'ENOENT' error should be caught and printed.