### PR TITLE
Release the fork as a @balena module until the PR gets merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
-# node-web-streams
+# @balena/node-web-streams
 WhatWG web streams and conversion utilities for node.js
+
+This is a fork of [gwicke's node-web-streams module](https://github.com/gwicke/node-web-streams),
+which exposes webstream read errors as node error events.
+This is meant to provide a proper npm release until
+[the respective upstream PR](https://github.com/gwicke/node-web-streams/pull/4)
+gets merged.
 
 This provides the [WhatWG streams](https://streams.spec.whatwg.org) API for
 node. It leverages the [WhatWG reference

--- a/lib/conversions.js
+++ b/lib/conversions.js
@@ -70,7 +70,8 @@ class NodeReadable extends Readable {
                     } else {
                         this._reading = false;
                     }
-                });
+                })
+                .catch(e => this.emit('error', e));
         };
         doRead();
     }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "dependencies": {
     "is-stream": "^1.1.0",
-    "web-streams-polyfill": "git://github.com/gwicke/web-streams-polyfill#spec_performance_improvements"
+    "web-streams-polyfill": "^1.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-web-streams",
+  "name": "@balena/node-web-streams",
   "version": "0.2.2",
   "description": "WhatWG web streams and conversion utilities for node.js",
   "main": "index.js",
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gwicke/node-web-streams.git"
+    "url": "https://github.com/balena-io-modules/node-web-streams.git"
   },
   "keywords": [
     "streamspec",
@@ -21,7 +21,7 @@
   "author": "Gabriel Wicke <gwicke@wikimedia.org>",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/gwicke/node-web-streams/issues"
+    "url": "https://github.com/balena-io-modules/node-web-streams/issues"
   },
   "dependencies": {
     "is-stream": "^1.1.0",


### PR DESCRIPTION
That's on top of https://github.com/gwicke/node-web-streams/pull/4 and just renames the package as a @balena one, so that it gets released on npm.

Change-type: patch